### PR TITLE
Fix Issue #16, broken TCPDriver MRO

### DIFF
--- a/lantz/network.py
+++ b/lantz/network.py
@@ -72,7 +72,7 @@ class TCPRawDriver(Driver):
         return self.socket.isOpen()
 
 
-class TCPDriver(TextualMixin, TCPRawDriver):
+class TCPDriver(TCPRawDriver, TextualMixin):
     """Base class for drivers that communicate with instruments via TCP.
 
     :param host: Address of the network resource


### PR DESCRIPTION
The TCPDriver was raising a `NotImplemented`
exception whenever `raw_send` or `raw_recv`
were called, directly or indirectly. This was
caused by an improper placement of `TextualMixin`
in the Method Resolution Order. Essentially, the
abstract versions of methods were overriding the
concrete implementations.
