### PR TITLE
Replaced enum backport package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ paths = os.listdir(folder)
 
 requirements = []
 if sys.version_info < (3, 4):
-    requirements.append('backport.enum')
+    requirements.append('enum34')
 
 companies = [path for path in paths
              if os.path.isdir(os.path.join(folder, path))


### PR DESCRIPTION
Backport.enum does not seem to exist anymore. Replacing it with enum34 fixes install for Python <3.4
